### PR TITLE
Turning cavity off before setting up

### DIFF
--- a/setup_gui.py
+++ b/setup_gui.py
@@ -102,6 +102,9 @@ class SetupWorker(QRunnable):
                 self.signals.finished.emit(f"RF and SSA off for {self.cavity}")
 
             else:
+                self.signals.status.emit("Turning cavity off")
+                self.cavity.turnOff()
+
                 self.signals.status.emit(
                     f"Turning on {self.cavity} SSA if not on already"
                 )


### PR DESCRIPTION
This prevents slamming on at full power if the RF state is on when we reset interlocks